### PR TITLE
Added missing `<getopt.h>` inclusion.

### DIFF
--- a/path.c
+++ b/path.c
@@ -1,3 +1,4 @@
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
A fresh clone and make of this project warned me that `getopt` was implicitly declared:

```
$ make
icc -c -std=c99 -g -O3 -no-prec-div -xcore-avx2 -ipo -qopt-report=5 -qopt-report-phase=vec -openmp path.c
icc: remark #10346: optimization reporting will be enabled at link time when performing interprocedural optimizations
path.c(214): warning #266: function "getopt" declared implicitly
      while ((c = getopt(argc, argv, optstring)) != -1) {
                  ^

path.c(214): warning #2330: argument of type "const char *" is incompatible with parameter of type "void *" (dropping qualifiers)
      while ((c = getopt(argc, argv, optstring)) != -1) {
                                     ^
...
```

This [StackOverflow post](http://stackoverflow.com/a/22576057/3187068) says to remove the `-std=c99` flag or explicitly include `getopt.h` to fix the problem. I opted for the latter. After this fix, everything builds without warning.
